### PR TITLE
Update slimbot.js

### DIFF
--- a/src/slimbot.js
+++ b/src/slimbot.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const EventEmitter = require('eventemitter3');
 const Telegram = require('./telegram');
 


### PR DESCRIPTION
This addresses an issue where meteor throw's an error at run time where it's requiring 'use strict' to allow es6 syntax (e.g. let, const, etc). Also throws an error because of missing return in promise ".then" functions